### PR TITLE
Made the unit test runner fail if some tests fail

### DIFF
--- a/checks/check_common.c
+++ b/checks/check_common.c
@@ -53,13 +53,6 @@ unsigned char *gen_random_data(size_t minlen, size_t maxlen, size_t *outlen) {
 }
 
 
-START_TEST (test_name)
-{
-	printf("Testing 1!\n");
-	printf("Testing 2!\n");
-}
-END_TEST
-
 #ifdef ERROR_API_FINISHED
 /** @brief Compute positive sum of two non-negative ints or raise errinfo error.
  * @param a first addend
@@ -133,7 +126,6 @@ Suite * test_suite(void) {
 	s = suite_create("test");
 	tcase = tcase_create("core");
 
-	tcase_add_test(tcase, test_name);
 #ifdef ERROR_API_FINISHED
 	tcase_add_test(tcase, errinfo_test);
 #endif /* ERROR_API_FINISHED */
@@ -146,7 +138,7 @@ Suite * test_suite(void) {
 int main(int argc, char *argv[]) {
 
 	SRunner *sr;
-//	int nr_failed;
+	int nr_failed;
 
 	sr = srunner_create(test_suite());
 	srunner_add_suite(sr, suite_check_misc());
@@ -154,17 +146,9 @@ int main(int argc, char *argv[]) {
 
 	fprintf(stderr, "Running tests ...\n");
 
-	srunner_run_all(sr, CK_SILENT);
-	//srunner_run_all(sr, CK_NORMAL);
-//	nr_failed = srunner_ntests_failed(sr);
-	// CK_VERBOSE
-	srunner_print(sr, CK_VERBOSE);
+	srunner_run_all(sr, CK_ENV);
+	nr_failed = srunner_ntests_failed(sr);
 	srunner_free(sr);
 
-	fprintf(stderr, "Finished.\n");
-
-	//ck_assert
-	//ck_assert_msg
-
-	return 0;
+	return nr_failed != 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/checks/check_crypto.c
+++ b/checks/check_crypto.c
@@ -114,16 +114,14 @@ START_TEST (load_ec_key_file)
 	size_t i;
 
 	for (i = 0; i < 5; i++) {
-		memset(filename, 0, sizeof(filename));
 		snprintf(filename, sizeof(filename), "ec-key-%zu-priv.pem", i+1);
 		result = load_ec_privkey(filename, &group);
-		ck_assert_msg((result != NULL), "EC key load from file check failed: error loading private key PEM file.\n");
+		ck_assert_msg(result != NULL, "load_ec_privkey failed for %s", filename);
 		free_ec_key(result);
 
-		memset(filename, 0, sizeof(filename));
 		snprintf(filename, sizeof(filename), "ec-key-%zu-pub.pem", i+1);
 		result = load_ec_privkey(filename, &group);
-		ck_assert_msg((result != NULL), "EC key load from file check failed: error loading public key PEM file.\n");
+		ck_assert_msg(result != NULL, "load_ec_privkey failed for %s", filename);
 		free_ec_key(result);
 	}
 

--- a/checks/check_misc.c
+++ b/checks/check_misc.c
@@ -26,18 +26,12 @@
 
 START_TEST (check_debug_level)
 {
-
-	unsigned int i, level;
-
-	fprintf(stderr, "Checking debug level functions / set_dbg_level()/get_dbg_level():\n");
+	unsigned int i;
 
 	for (i = 0; i < 100; i++) {
 		set_dbg_level(i);
-		level = get_dbg_level();
-		ck_assert_msg(i == level, "Debug level change test failed; expected %u but read %u.\n", i, level);
+		ck_assert_uint_eq(i, get_dbg_level());
 	}
-
-	fprintf(stderr, "Debug level check ended.\n");
 }
 END_TEST
 


### PR DESCRIPTION
The program that runs the unit tests must exit with a nonzero status in
case of failures or errors.

While here, cleaned up the tests a bit.