### PR TITLE
Fixed base64 macros

### DIFF
--- a/checks/check_misc.c
+++ b/checks/check_misc.c
@@ -41,6 +41,25 @@ START_TEST (check_debug_level)
 }
 END_TEST
 
+START_TEST(check_base64_macros)
+{
+	ck_assert_uint_eq(0, B64_ENCODED_LEN(0));
+	ck_assert_uint_eq(4, B64_ENCODED_LEN(1));
+	ck_assert_uint_eq(4, B64_ENCODED_LEN(2));
+	ck_assert_uint_eq(4, B64_ENCODED_LEN(3));
+	ck_assert_uint_eq(40, B64_ENCODED_LEN(30));
+	ck_assert_uint_eq(44, B64_ENCODED_LEN(31));
+	ck_assert_uint_eq(40, B64_ENCODED_LEN(10 + 10 + 10));
+
+	ck_assert_uint_eq(0, BASE64_DECODED_LEN(0));
+	ck_assert_uint_eq(1, BASE64_DECODED_LEN(2));
+	ck_assert_uint_eq(2, BASE64_DECODED_LEN(3));
+	ck_assert_uint_eq(3, BASE64_DECODED_LEN(4));
+	ck_assert_uint_eq(57, BASE64_DECODED_LEN(76));
+	ck_assert_uint_eq(30 + 30 + 30, BASE64_DECODED_LEN(40 + 40 + 40));
+}
+END_TEST
+
 
 Suite * suite_check_misc(void) {
 
@@ -49,6 +68,7 @@ Suite * suite_check_misc(void) {
 
 	s = suite_create("misc");
 	testcase(s, tc, "Debug Level Check", check_debug_level);
+	testcase(s, tc, "Base64 Macros", check_base64_macros);
 
 	return s;
 }

--- a/include/misc.h
+++ b/include/misc.h
@@ -27,8 +27,8 @@
 
 #define SHA_512_B64_SIZE	86
 
-#define B64_ENCODED_LEN(len)	(((len + ((len % 3) ? (3 - (len % 3)) : 0)) / 3) * 4)
-#define BASE64_DECODED_LEN(len)	(len * 3/4)
+#define B64_ENCODED_LEN(len)	((((len) + (((len) % 3) ? (3 - ((len) % 3)) : 0)) / 3) * 4)
+#define BASE64_DECODED_LEN(len)	((len) * 3/4)
 
 
 typedef struct {


### PR DESCRIPTION
Arguments to macros must be enclosed in parentheses, if they are to be interpreted as expressions.